### PR TITLE
Add BookProfile model — 7 reading-dimension scores per book (#94)

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,5 +1,6 @@
 class Book < ApplicationRecord
   belongs_to :user
+  has_one :book_profile
 
   enum :rating, {meh: 1, liked: 2, loved: 3}
 
@@ -10,4 +11,8 @@ class Book < ApplicationRecord
   scope :by_genre, ->(g) { where(genre: g) }
   scope :recent, -> { order(read_at: :desc, created_at: :desc) }
   scope :search, ->(q) { where("title LIKE ? OR author LIKE ? OR notes LIKE ?", "%#{q}%", "%#{q}%", "%#{q}%") }
+
+  def profiled?
+    book_profile.present?
+  end
 end

--- a/app/models/book_profile.rb
+++ b/app/models/book_profile.rb
@@ -1,0 +1,4 @@
+class BookProfile < ApplicationRecord
+  belongs_to :book
+  validates :book, uniqueness: true
+end

--- a/db/migrate/20260519140441_create_book_profiles.rb
+++ b/db/migrate/20260519140441_create_book_profiles.rb
@@ -1,0 +1,16 @@
+class CreateBookProfiles < ActiveRecord::Migration[8.1]
+  def change
+    create_table :book_profiles do |t|
+      t.references :book, null: false, foreign_key: true, index: {unique: true}
+      t.float :pace
+      t.float :emotional_weight
+      t.float :character_depth
+      t.float :world_building
+      t.float :prose_complexity
+      t.float :plot_intricacy
+      t.float :darkness
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_095309) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_19_140441) do
+  create_table "book_profiles", force: :cascade do |t|
+    t.integer "book_id", null: false
+    t.float "character_depth"
+    t.datetime "created_at", null: false
+    t.float "darkness"
+    t.float "emotional_weight"
+    t.float "pace"
+    t.float "plot_intricacy"
+    t.float "prose_complexity"
+    t.datetime "updated_at", null: false
+    t.float "world_building"
+    t.index ["book_id"], name: "index_book_profiles_on_book_id", unique: true
+  end
+
+
   create_table "books", force: :cascade do |t|
     t.string "author"
     t.string "cover_url"
@@ -228,6 +243,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_095309) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "book_profiles", "books"
   add_foreign_key "books", "users"
   add_foreign_key "friendships", "users"
   add_foreign_key "friendships", "users", column: "friend_id"

--- a/test/fixtures/book_profiles.yml
+++ b/test/fixtures/book_profiles.yml
@@ -1,0 +1,9 @@
+one:
+  book: beloved
+  pace: 0.8
+  emotional_weight: 0.9
+  character_depth: 0.7
+  world_building: 0.4
+  prose_complexity: 0.6
+  plot_intricacy: 0.5
+  darkness: 0.8

--- a/test/models/book_profile_test.rb
+++ b/test/models/book_profile_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class BookProfileTest < ActiveSupport::TestCase
+  test "valid profile saves successfully" do
+    profile = BookProfile.new(
+      book: books(:sapiens),
+      pace: 0.8,
+      emotional_weight: 0.9,
+      character_depth: 0.7,
+      world_building: 0.4,
+      prose_complexity: 0.6,
+      plot_intricacy: 0.5,
+      darkness: 0.8
+    )
+    assert profile.valid?
+    assert profile.save
+  end
+
+  test "invalid without book" do
+    profile = BookProfile.new(pace: 0.5)
+    assert_not profile.valid?
+    assert_includes profile.errors[:book], "must exist"
+  end
+
+  test "validates uniqueness of book" do
+    existing = book_profiles(:one)
+    duplicate = BookProfile.new(book: existing.book, pace: 0.5)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:book], "has already been taken"
+  end
+
+  test "all 7 dimension columns accept nil" do
+    profile = BookProfile.new(book: books(:meh_book))
+    assert profile.valid?
+    assert_nil profile.pace
+    assert_nil profile.emotional_weight
+    assert_nil profile.character_depth
+    assert_nil profile.world_building
+    assert_nil profile.prose_complexity
+    assert_nil profile.plot_intricacy
+    assert_nil profile.darkness
+  end
+
+  test "pace accepts values between 0.0 and 1.0" do
+    profile = BookProfile.new(book: books(:meh_book), pace: 0.0)
+    assert profile.valid?
+    profile.pace = 1.0
+    assert profile.valid?
+    profile.pace = 0.5
+    assert profile.valid?
+  end
+
+  test "emotional_weight accepts values between 0.0 and 1.0" do
+    profile = BookProfile.new(book: books(:meh_book), emotional_weight: 0.0)
+    assert profile.valid?
+    profile.emotional_weight = 1.0
+    assert profile.valid?
+  end
+
+  test "character_depth accepts values between 0.0 and 1.0" do
+    profile = BookProfile.new(book: books(:meh_book), character_depth: 0.0)
+    assert profile.valid?
+    profile.character_depth = 1.0
+    assert profile.valid?
+  end
+
+  test "world_building accepts values between 0.0 and 1.0" do
+    profile = BookProfile.new(book: books(:meh_book), world_building: 0.0)
+    assert profile.valid?
+    profile.world_building = 1.0
+    assert profile.valid?
+  end
+
+  test "prose_complexity accepts values between 0.0 and 1.0" do
+    profile = BookProfile.new(book: books(:meh_book), prose_complexity: 0.0)
+    assert profile.valid?
+    profile.prose_complexity = 1.0
+    assert profile.valid?
+  end
+
+  test "plot_intricacy accepts values between 0.0 and 1.0" do
+    profile = BookProfile.new(book: books(:meh_book), plot_intricacy: 0.0)
+    assert profile.valid?
+    profile.plot_intricacy = 1.0
+    assert profile.valid?
+  end
+
+  test "darkness accepts values between 0.0 and 1.0" do
+    profile = BookProfile.new(book: books(:meh_book), darkness: 0.0)
+    assert profile.valid?
+    profile.darkness = 1.0
+    assert profile.valid?
+  end
+end

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -1,7 +1,17 @@
 require "test_helper"
 
 class BookTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "profiled? returns false when no profile exists" do
+    assert_not books(:meh_book).profiled?
+  end
+
+  test "profiled? returns true when a profile exists" do
+    assert books(:beloved).profiled?
+  end
+
+  test "book_profile returns the associated profile" do
+    profile = books(:beloved).book_profile
+    assert_instance_of BookProfile, profile
+    assert_equal books(:beloved), profile.book
+  end
 end


### PR DESCRIPTION
## Summary
- Adds \`book_profiles\` table with 7 float dimension columns: \`pace\`, \`emotional_weight\`, \`character_depth\`, \`world_building\`, \`prose_complexity\`, \`plot_intricacy\`, \`darkness\` (all nullable, 0.0–1.0)
- Unique index on \`book_id\` + foreign key constraint
- \`BookProfile\` model with \`belongs_to :book\` and uniqueness validation
- \`Book\` gets \`has_one :book_profile\` and a \`profiled?\` predicate

## Test plan
- [ ] Migration runs and rolls back cleanly
- [ ] \`book.profiled?\` returns false / true correctly
- [ ] Uniqueness validation prevents duplicate profiles per book
- [ ] All dimension columns accept nil (profile exists before scoring completes)
- [ ] \`bin/rails test test/models/book_profile_test.rb test/models/book_test.rb\`

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)