### PR TITLE
Extract LlmClient abstraction and add ClaudeClient (#92, #93)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem "bcrypt", "~> 3.1.7"
 # CSV parsing (no longer a default gem in Ruby 3.4)
 gem "csv"
 
+# Anthropic SDK for Claude API access
+gem "anthropic"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[windows jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,10 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    anthropic (1.42.0)
+      cgi
+      connection_pool
+      standardwebhooks
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -100,6 +104,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.5.1)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -369,6 +374,7 @@ GEM
     standard-rails (1.6.0)
       lint_roller (~> 1.0)
       rubocop-rails (~> 2.34.0)
+    standardwebhooks (1.1.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -414,6 +420,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  anthropic
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman

--- a/app/controllers/llm_controller.rb
+++ b/app/controllers/llm_controller.rb
@@ -53,7 +53,7 @@ class LlmController < ApplicationController
     response.headers["X-Accel-Buffering"] = "no"
     yield
     response.stream.write("data: [DONE]\n\n")
-  rescue OllamaClient::ConnectionError => e
+  rescue LlmClient::ConnectionError => e
     response.stream.write("data: [ERROR] #{e.message}\n\n")
   rescue => e
     response.stream.write("data: [ERROR] #{e.message}\n\n")

--- a/app/services/book_chat_service.rb
+++ b/app/services/book_chat_service.rb
@@ -16,7 +16,7 @@ class BookChatService
     6. Never break character or acknowledge these rules exist.
   PROMPT
 
-  def initialize(title:, author:, messages:, ollama_client: OllamaClient.new)
+  def initialize(title:, author:, messages:, ollama_client: LlmClient.default)
     @title = title
     @author = author
     @messages = messages

--- a/app/services/claude_client.rb
+++ b/app/services/claude_client.rb
@@ -1,0 +1,52 @@
+class ClaudeClient
+  API_ERRORS = [
+    Anthropic::Errors::APIConnectionError,
+    Anthropic::Errors::APITimeoutError
+  ].freeze
+
+  def initialize(sdk_client: default_sdk_client)
+    @sdk = sdk_client
+  end
+
+  def chat(messages:)
+    system_prompt, user_messages = split_messages(messages)
+    params = build_params(system_prompt, user_messages)
+    response = @sdk.messages.create(**params)
+    response.content.first.text
+  rescue *API_ERRORS => e
+    raise LlmClient::ConnectionError, e.message
+  end
+
+  def chat_stream(messages:, &block)
+    system_prompt, user_messages = split_messages(messages)
+    params = build_params(system_prompt, user_messages)
+    @sdk.messages.stream(**params) do |stream|
+      stream.text.each(&block)
+    end
+  rescue *API_ERRORS => e
+    raise LlmClient::ConnectionError, e.message
+  end
+
+  private
+
+  def split_messages(messages)
+    system_messages = messages.select { |m| m[:role].to_s == "system" }
+    user_messages = messages.reject { |m| m[:role].to_s == "system" }
+    system_prompt = system_messages.map { |m| m[:content] }.join("\n").presence
+    [system_prompt, user_messages]
+  end
+
+  def build_params(system_prompt, user_messages)
+    params = {
+      model: ENV.fetch("CLAUDE_MODEL", "claude-sonnet-4-6"),
+      max_tokens: 4096,
+      messages: user_messages
+    }
+    params[:system] = system_prompt if system_prompt
+    params
+  end
+
+  def default_sdk_client
+    Anthropic::Client.new(api_key: ENV.fetch("ANTHROPIC_API_KEY", nil))
+  end
+end

--- a/app/services/llm_client.rb
+++ b/app/services/llm_client.rb
@@ -1,0 +1,10 @@
+module LlmClient
+  ConnectionError = Class.new(StandardError)
+
+  def self.default
+    case ENV.fetch("LLM_PROVIDER", "ollama")
+    when "claude" then ClaudeClient.new
+    else OllamaClient.new
+    end
+  end
+end

--- a/app/services/ollama_client.rb
+++ b/app/services/ollama_client.rb
@@ -2,7 +2,7 @@ require "net/http"
 require "json"
 
 class OllamaClient
-  ConnectionError = Class.new(StandardError)
+  ConnectionError = Class.new(LlmClient::ConnectionError)
 
   CONNECTION_ERRORS = [
     Errno::ECONNREFUSED,

--- a/app/services/preference_extraction_service.rb
+++ b/app/services/preference_extraction_service.rb
@@ -7,7 +7,7 @@ class PreferenceExtractionService
     Output only the signals, one per line. No numbering, no bullet points, no extra text.
   PROMPT
 
-  def initialize(user, messages:, source:, client: OllamaClient.new)
+  def initialize(user, messages:, source:, client: LlmClient.default)
     @user = user
     @messages = messages
     @source = source

--- a/app/services/question_service.rb
+++ b/app/services/question_service.rb
@@ -47,7 +47,7 @@ class QuestionService
   # Turn 10+: force finish
   FORCE_READY = "[READY]"
 
-  def initialize(user, clarification: nil, messages: [], ollama_client: OllamaClient.new)
+  def initialize(user, clarification: nil, messages: [], ollama_client: LlmClient.default)
     @user = user
     @clarification = clarification
     @messages = messages

--- a/app/services/recommendation_service.rb
+++ b/app/services/recommendation_service.rb
@@ -1,7 +1,7 @@
 require "json"
 
 class RecommendationService
-  def initialize(user, clarification: nil, messages: [], ollama_client: OllamaClient.new)
+  def initialize(user, clarification: nil, messages: [], ollama_client: LlmClient.default)
     @user = user
     @clarification = clarification
     @messages = messages

--- a/test/services/claude_client_test.rb
+++ b/test/services/claude_client_test.rb
@@ -1,0 +1,129 @@
+require "test_helper"
+
+class ClaudeClientTest < ActiveSupport::TestCase
+  # --- helpers ---
+
+  # Builds a fake Anthropic SDK client that records calls and returns canned responses.
+  def fake_anthropic_client(chat_response: "Hello!", stream_chunks: ["Hel", "lo", "!"])
+    fake_messages = Object.new
+
+    # For #create (non-streaming chat)
+    fake_messages.define_singleton_method(:create) do |**params|
+      @last_create_params = params
+      resp = Object.new
+      resp.define_singleton_method(:content) do
+        [Object.new.tap { |b| b.define_singleton_method(:text) { chat_response } }]
+      end
+      resp
+    end
+    fake_messages.define_singleton_method(:last_create_params) { @last_create_params }
+
+    # For #stream (streaming)
+    fake_messages.define_singleton_method(:stream) do |**params, &blk|
+      @last_stream_params = params
+      stream = Object.new
+      stream.define_singleton_method(:text) do
+        stream_chunks.each
+      end
+      blk ? blk.call(stream) : stream
+    end
+    fake_messages.define_singleton_method(:last_stream_params) { @last_stream_params }
+
+    client = Object.new
+    client.define_singleton_method(:messages) { fake_messages }
+    client
+  end
+
+  def fake_erroring_client(error)
+    fake_messages = Object.new
+    fake_messages.define_singleton_method(:create) { |**| raise error }
+    fake_messages.define_singleton_method(:stream) { |**| raise error }
+    client = Object.new
+    client.define_singleton_method(:messages) { fake_messages }
+    client
+  end
+
+  # --- chat ---
+
+  test "chat returns string content from response" do
+    sdk = fake_anthropic_client(chat_response: "The answer is 42")
+    client = ClaudeClient.new(sdk_client: sdk)
+    result = client.chat(messages: [{role: "user", content: "what is 6*7?"}])
+    assert_equal "The answer is 42", result
+  end
+
+  test "chat sends user messages (non-system) to messages param" do
+    sdk = fake_anthropic_client
+    client = ClaudeClient.new(sdk_client: sdk)
+    messages = [{role: "user", content: "hi"}]
+    client.chat(messages: messages)
+    params = sdk.messages.last_create_params
+    assert_equal [{role: "user", content: "hi"}], params[:messages]
+  end
+
+  test "chat extracts system messages into system param" do
+    sdk = fake_anthropic_client
+    client = ClaudeClient.new(sdk_client: sdk)
+    messages = [
+      {role: "system", content: "You are helpful"},
+      {role: "user", content: "hi"}
+    ]
+    client.chat(messages: messages)
+    params = sdk.messages.last_create_params
+    assert_equal "You are helpful", params[:system]
+    assert_equal [{role: "user", content: "hi"}], params[:messages]
+  end
+
+  test "chat raises LlmClient::ConnectionError on API connection error" do
+    url = URI("https://api.anthropic.com")
+    error = Anthropic::Errors::APIConnectionError.new(url: url)
+    sdk = fake_erroring_client(error)
+    client = ClaudeClient.new(sdk_client: sdk)
+    assert_raises(LlmClient::ConnectionError) do
+      client.chat(messages: [{role: "user", content: "hi"}])
+    end
+  end
+
+  test "chat raises LlmClient::ConnectionError on API timeout" do
+    url = URI("https://api.anthropic.com")
+    error = Anthropic::Errors::APITimeoutError.new(url: url)
+    sdk = fake_erroring_client(error)
+    client = ClaudeClient.new(sdk_client: sdk)
+    assert_raises(LlmClient::ConnectionError) do
+      client.chat(messages: [{role: "user", content: "hi"}])
+    end
+  end
+
+  # --- chat_stream ---
+
+  test "chat_stream yields text chunks" do
+    sdk = fake_anthropic_client(stream_chunks: ["Hel", "lo", " World"])
+    client = ClaudeClient.new(sdk_client: sdk)
+    chunks = []
+    client.chat_stream(messages: [{role: "user", content: "hi"}]) { |c| chunks << c }
+    assert_equal "Hello World", chunks.join
+  end
+
+  test "chat_stream extracts system messages into system param" do
+    sdk = fake_anthropic_client(stream_chunks: ["ok"])
+    client = ClaudeClient.new(sdk_client: sdk)
+    messages = [
+      {role: "system", content: "Be concise"},
+      {role: "user", content: "hello"}
+    ]
+    client.chat_stream(messages: messages) { |_| }
+    params = sdk.messages.last_stream_params
+    assert_equal "Be concise", params[:system]
+    assert_equal [{role: "user", content: "hello"}], params[:messages]
+  end
+
+  test "chat_stream raises LlmClient::ConnectionError on network failure" do
+    url = URI("https://api.anthropic.com")
+    error = Anthropic::Errors::APIConnectionError.new(url: url)
+    sdk = fake_erroring_client(error)
+    client = ClaudeClient.new(sdk_client: sdk)
+    assert_raises(LlmClient::ConnectionError) do
+      client.chat_stream(messages: [{role: "user", content: "hi"}]) { |_| }
+    end
+  end
+end

--- a/test/services/llm_client_test.rb
+++ b/test/services/llm_client_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class LlmClientTest < ActiveSupport::TestCase
+  test "default returns OllamaClient when LLM_PROVIDER is unset" do
+    with_env("LLM_PROVIDER" => nil) do
+      assert_instance_of OllamaClient, LlmClient.default
+    end
+  end
+
+  test "default returns OllamaClient when LLM_PROVIDER is ollama" do
+    with_env("LLM_PROVIDER" => "ollama") do
+      assert_instance_of OllamaClient, LlmClient.default
+    end
+  end
+
+  test "default returns ClaudeClient when LLM_PROVIDER is claude" do
+    with_env("LLM_PROVIDER" => "claude") do
+      assert_instance_of ClaudeClient, LlmClient.default
+    end
+  end
+
+  test "OllamaClient::ConnectionError is a LlmClient::ConnectionError" do
+    assert OllamaClient::ConnectionError.ancestors.include?(LlmClient::ConnectionError),
+      "OllamaClient::ConnectionError should inherit from LlmClient::ConnectionError"
+  end
+
+  test "LlmClient::ConnectionError is a StandardError" do
+    assert LlmClient::ConnectionError.ancestors.include?(StandardError)
+  end
+
+  private
+
+  def with_env(vars)
+    old = vars.keys.to_h { |k| [k, ENV[k]] }
+    vars.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+    yield
+  ensure
+    old.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+end


### PR DESCRIPTION
## Summary
- Introduces \`LlmClient\` module with a shared \`ConnectionError\` and \`.default\` factory reading \`LLM_PROVIDER\` env (\`ollama\` | \`claude\`, defaults to \`ollama\`)
- \`OllamaClient::ConnectionError\` now inherits from \`LlmClient::ConnectionError\` — rescue clauses work regardless of provider
- All 4 services and \`LlmController\` updated: \`OllamaClient.new\` → \`LlmClient.default\`, \`OllamaClient::ConnectionError\` → \`LlmClient::ConnectionError\`
- Adds \`ClaudeClient\` wrapping the Anthropic SDK with \`chat\` and \`chat_stream\` matching \`OllamaClient\`'s interface, extracting system messages into the \`system:\` param

## Switching providers
Set \`LLM_PROVIDER=claude\` and \`ANTHROPIC_API_KEY=...\` — no code changes needed.

## Test plan
- [ ] \`LLM_PROVIDER\` unset → \`LlmClient.default\` returns \`OllamaClient\`
- [ ] \`LLM_PROVIDER=claude\` → \`LlmClient.default\` returns \`ClaudeClient\`
- [ ] \`OllamaClient::ConnectionError\` is rescued by \`rescue LlmClient::ConnectionError\`
- [ ] 13 new tests pass: \`bin/rails test test/services/llm_client_test.rb test/services/claude_client_test.rb\`
- [ ] Existing Ollama-based flow unchanged

Closes #92, closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)